### PR TITLE
Adding googletest to submodules to pass its Actions test and not clut…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       # Step 1: Checkout the code
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       # Step 2: Install dependencies
       - name: Install dependencies

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "googletest"]
+	path = googletest
+	url = https://github.com/google/googletest.git


### PR DESCRIPTION
# Pull Request: Add GoogleTest Submodule for CI Compatibility

## Description
This pull request adds `googletest` as a submodule to enable proper test verification in CI workflows. Without this submodule, GitHub Actions fails to locate `googletest` during the build-and-test process, causing consistent workflow failures.

## Type of Changes
<!-- Check the relevant box: -->
- [ ] New feature (non-breaking change)
- [ ] Bug fix (non-breaking change)
- [x] Breaking change (affects CI/CD setup or changes existing functionality)
- [ ] Documentation update

## Changes Overview
- **`.ci.yml`** – Updated to ensure GitHub Actions can access submodules during testing.
- **`.gitmodules`** – Added `googletest` as a submodule for consistent test availability in CI.

## Testing Instructions
1. Push these changes to the `master` branch.
2. Verify that the `build-and-test` workflow completes successfully without encountering the following error:
   ```plaintext
   Run cmake -S . -B build -G Ninja
   -- The C compiler identification is GNU 11.4.0
   -- The CXX compiler identification is GNU 11.4.0
   -- Detecting C compiler ABI info
   -- Detecting C compiler ABI info - done
   -- Check for working C compiler: /usr/bin/cc - skipped
   -- Detecting C compile features
   -- Detecting C compile features - done
   -- Detecting CXX compiler ABI info
   -- Detecting CXX compiler ABI info - done
   -- Check for working CXX compiler: /usr/bin/c++ - skipped
   -- Detecting CXX compile features
   -- Detecting CXX compile features - done
   CMake Error at CMakeLists.txt:12 (add_subdirectory):
     add_subdirectory given source "googletest" which is not an existing
     directory.
```