### PR TITLE
Add queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ add_executable(DataStructures
         main.cpp
         Array/DynamicArray.h
         LinkedList/DoublyLinkedList.h
-        Stack/Stack.h)
+        Stack/Stack.h
+        Queue/Queue.h)
 
 # GTest Support
 enable_testing()
@@ -26,12 +27,18 @@ add_executable(stack_test
         tests/test_stack.cpp
         Stack/Stack.h)
 
+add_executable(queue_test
+        tests/test_queue.cpp
+        Queue/Queue.h)
+
 # Link GTest
 target_link_libraries(dynamic_array_test gtest gtest_main)
 target_link_libraries(linked_list_test gtest gtest_main)
 target_link_libraries(stack_test gtest gtest_main)
+target_link_libraries(queue_test gtest gtest_main)
 
 # Register the test with CMake
 add_test(NAME DynamicArrayTest COMMAND dynamic_array_test)
 add_test(NAME LinkedListTest COMMAND linked_list_test)
 add_test(NAME StackTest COMMAND stack_test)
+add_test(NAME QueueTest COMMAND queue_test)

--- a/Queue/Queue.h
+++ b/Queue/Queue.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../LinkedList/DoublyLinkedList.h"
+
+template <typename T>
+class Deque {
+public:
+    Deque();
+    ~Deque();
+
+    void enqueue_left(T value);
+    void enqueue_right(T value);
+    void dequeue_left();
+    void dequeue_right();
+    void
+    T front() const;
+
+private:
+    DoublyLinkedList<T> deque;
+};

--- a/Queue/Queue.h
+++ b/Queue/Queue.h
@@ -3,18 +3,61 @@
 #include "../LinkedList/DoublyLinkedList.h"
 
 template <typename T>
-class Deque {
+class Queue {
 public:
-    Deque();
-    ~Deque();
+    Queue();
+    ~Queue();
 
-    void enqueue_left(T value);
-    void enqueue_right(T value);
-    void dequeue_left();
-    void dequeue_right();
-    void
-    T front() const;
+    void enqueue(T value);
+    void dequeue();
+    T peek() const;
+    bool contains(T value);
+
+    int getSize() const;
+    bool isEmpty() const;
+
 
 private:
-    DoublyLinkedList<T> deque;
+    DoublyLinkedList<T> queue;
 };
+
+template <typename T>
+Queue<T>::Queue() = default;
+
+template <typename T>
+Queue<T>::~Queue() {
+    queue.clear();
+}
+
+template <typename T>
+void Queue<T>::enqueue(T value) {
+    queue.addLast(value);
+}
+
+template <typename T>
+void Queue<T>::dequeue() {
+    queue.removeFirst();
+}
+
+template <typename T>
+T Queue<T>::peek() const{
+    return queue.peekFirst();
+}
+
+template <typename T>
+bool Queue<T>::contains(T value) {
+    return queue.contains(value);
+}
+
+template<typename T>
+int Queue<T>::getSize() const {
+    return queue.getSize();
+}
+
+template<typename T>
+bool Queue<T>::isEmpty() const {
+    return queue.isEmpty();
+}
+
+
+

--- a/Stack/Stack.h
+++ b/Stack/Stack.h
@@ -4,9 +4,6 @@
 
 template<typename T>
 class Stack {
-private:
-
-    DoublyLinkedList<T> stack;
 public:
     Stack();
     ~Stack();
@@ -16,6 +13,10 @@ public:
     void push(const T& elem);
     int getSize() const;
     bool isEmpty() const;
+
+private:
+
+    DoublyLinkedList<T> stack;
 };
 
 template<typename T>

--- a/tests/test_queue.cpp
+++ b/tests/test_queue.cpp
@@ -1,0 +1,101 @@
+#include <gtest/gtest.h>
+#include "../Queue/Queue.h"
+
+class QueueTest : public ::testing::Test {
+protected:
+    Queue<int> queue;
+
+    void SetUp() override {
+
+    }
+};
+
+TEST_F(QueueTest, InitialQueueIsEmpty) {
+    EXPECT_EQ(queue.getSize(), 0);
+    EXPECT_TRUE(queue.isEmpty());
+}
+
+TEST_F(QueueTest, PushToQueue) {
+    queue.enqueue(5);
+    EXPECT_EQ(queue.getSize(), 1);
+    EXPECT_FALSE(queue.isEmpty());
+
+    for (int i = 0; i < 10; ++i) {
+        queue.enqueue(i);
+    }
+    EXPECT_EQ(queue.getSize(), 11);
+
+}
+
+TEST_F(QueueTest, PushSingleAndPop) {
+    queue.enqueue(42);
+    EXPECT_EQ(queue.peek(), 42);
+    queue.dequeue();
+    EXPECT_TRUE(queue.isEmpty());
+}
+
+TEST_F(QueueTest, StressTest) {
+    constexpr int largeSize = 1000000;
+    for (int i = 0; i < largeSize; ++i) {
+        queue.enqueue(i);
+    }
+    EXPECT_EQ(queue.getSize(), largeSize);
+
+    for (int i = 0; i < largeSize; ++i) {
+        EXPECT_EQ(queue.peek(), i);
+        queue.dequeue();
+    }
+    EXPECT_TRUE(queue.isEmpty());
+}
+
+TEST_F(QueueTest, PopFromQueue) {
+    for (int i = 0; i < 10; ++i) {
+        queue.enqueue(i*i*i);
+    }
+    EXPECT_EQ(queue.getSize(), 10);
+
+    queue.dequeue();
+    EXPECT_EQ(queue.getSize(), 9);
+    const int counter = queue.getSize();
+    for (int i = 0; i < counter; ++i) {
+        queue.dequeue();
+    }
+
+    EXPECT_TRUE(queue.isEmpty());
+    EXPECT_EQ(queue.getSize(), 0);
+}
+
+TEST_F(QueueTest, PeekQueue) {
+    for (int i = 0; i < 10; ++i) {
+        queue.enqueue(i*2);
+    }
+
+    EXPECT_EQ(queue.peek(), 0);
+    queue.dequeue();
+
+    EXPECT_EQ(queue.peek(), 2);
+}
+
+TEST_F(QueueTest, PeekEmptyQueueThrows) {
+    EXPECT_THROW(queue.peek(), std::out_of_range);
+}
+
+TEST_F(QueueTest, RemoveFromEmptyQueue) {
+    EXPECT_THROW(queue.dequeue(), std::out_of_range);
+    EXPECT_EQ(queue.getSize(), 0);
+}
+
+struct CustomData {
+    int id;
+    std::string name;
+};
+
+TEST_F(QueueTest, CustomDataType) {
+    Queue<CustomData> customQueue;
+    customQueue.enqueue({1, "Jesse"});
+    customQueue.enqueue({2, "Walter"});
+
+    EXPECT_EQ(customQueue.peek().name, "Jesse");
+    customQueue.dequeue();
+    EXPECT_EQ(customQueue.peek().name, "Walter");
+}

--- a/tests/test_stack.cpp
+++ b/tests/test_stack.cpp
@@ -35,7 +35,7 @@ TEST_F(StackTest, PushSingleAndPop) {
 }
 
 TEST_F(StackTest, StressTest) {
-    const int largeSize = 1000000;
+    constexpr int largeSize = 1000000;
     for (int i = 0; i < largeSize; ++i) {
         stack.push(i);
     }
@@ -56,7 +56,7 @@ TEST_F(StackTest, PopFromStack) {
 
     stack.pop();
     EXPECT_EQ(stack.getSize(), 9);
-    int counter = stack.getSize();
+    const int counter = stack.getSize();
     for (int i = 0; i < counter; ++i) {
         stack.pop();
     }


### PR DESCRIPTION
# Add Queue
<!-- Provide a clear and descriptive title for this pull request. -->

## Description
This PR introduces a Queue data structure implemented in C++ using templates to allow generic data types. The `Queue` supports the following core operations:

- enqueue(value): Add an element to the back of the `Queue`.
- dequeue(): Remove and return the element at the front of the `Queue`.
- peek(): View the front element without removing it.
- isEmpty(): Check if the `Queue` is empty.
- size(): Get the current size of the `Queue`.

This implementation includes a test suite to verify functionality under various scenarios, such as adding, removing, and edge cases like empty queues.

## Type of Changes
<!-- Check the box that applies: -->
- [x] New feature (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## How to Test
<!-- Describe how reviewers can test these changes. -->
1. Build the project using CMake.
2. Run the `queue_test` executable.
3. Verify the output:
- Enqueuing elements increases the size correctly.
- Dequeuing elements returns them in the correct order (FIFO).
- Peeking does not modify the queue.
- The queue behaves correctly when empty (e.g., dequeue returns an error or throws an exception).

## Notes / Additional Context
Future plans include extending this implementation to a `Deque`, allowing enqueue and dequeue operations at both ends.
