### PR TITLE
Add priority queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ add_executable(DataStructures
         Array/DynamicArray.h
         LinkedList/DoublyLinkedList.h
         Stack/Stack.h
-        Queue/Queue.h)
+        Queue/Queue.h
+        Queue/PriorityQueue.h)
 
 # GTest Support
 enable_testing()
@@ -31,14 +32,20 @@ add_executable(queue_test
         tests/test_queue.cpp
         Queue/Queue.h)
 
+add_executable(priority_queue_test
+        tests/test_priority_queue.cpp
+        Queue/PriorityQueue.h)
+
 # Link GTest
 target_link_libraries(dynamic_array_test gtest gtest_main)
 target_link_libraries(linked_list_test gtest gtest_main)
 target_link_libraries(stack_test gtest gtest_main)
 target_link_libraries(queue_test gtest gtest_main)
+target_link_libraries(priority_queue_test gtest gtest_main)
 
 # Register the test with CMake
 add_test(NAME DynamicArrayTest COMMAND dynamic_array_test)
 add_test(NAME LinkedListTest COMMAND linked_list_test)
 add_test(NAME StackTest COMMAND stack_test)
 add_test(NAME QueueTest COMMAND queue_test)
+add_test(NAME PriorityQueueTest COMMAND priority_queue_test)

--- a/Queue/PriorityQueue.h
+++ b/Queue/PriorityQueue.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../LinkedList/DoublyLinkedList.h"
+
+template <typename T>
+class PriorityQueue {
+public:
+    PriorityQueue();
+    ~PriorityQueue();
+
+
+private:
+    DoublyLinkedList<T> priorityQueue;
+};

--- a/Queue/PriorityQueue.h
+++ b/Queue/PriorityQueue.h
@@ -1,14 +1,126 @@
 #pragma once
 
-#include "../LinkedList/DoublyLinkedList.h"
-
 template <typename T>
 class PriorityQueue {
 public:
     PriorityQueue();
     ~PriorityQueue();
 
+    void push(T value);
+    void pop();
+    T peek() const;
+    size_t size() const;
+    bool isEmpty() const;
+    void clear();
+
+
 
 private:
-    DoublyLinkedList<T> priorityQueue;
+    std::vector<T> heap;
+    void heapifyUp();
+    void heapifyDown();
 };
+
+template<typename T>
+PriorityQueue<T>::PriorityQueue() = default;
+
+template<typename T>
+PriorityQueue<T>::~PriorityQueue() {
+    heap.clear();
+}
+
+template <typename T>
+void PriorityQueue<T>::push(T value) {
+    heap.push_back(value);
+    heap.heapifyUp();
+}
+
+template <typename T>
+void PriorityQueue<T>::pop() {
+    if (heap.empty()) {
+        throw std::runtime_error("Heap is empty");
+    }
+    if (heap.size() == 1) {
+        heap.pop_back();
+        return;
+    }
+    std::swap(heap[0], heap.back());
+    heap.pop_back();
+    heap.heapifyDown();
+}
+
+template<typename T>
+void PriorityQueue<T>::heapifyUp() {
+    // Empty heaps or single element heaps that never require swapping
+    if (heap.size() <= 1) {
+        return;
+    }
+
+    size_t idx = heap.size() - 1;
+    size_t parentIdx = (idx - 1) / 2;
+
+    while (idx > 0 && heap[idx] < heap[parentIdx]) {
+        std::swap(heap[idx], heap[parentIdx]);
+        idx = parentIdx;
+        parentIdx = (parentIdx - 1) / 2;
+    }
+}
+
+template<typename T>
+void PriorityQueue<T>::heapifyDown() {
+    // Empty heaps or single element heaps that never require swapping
+    if (heap.size() <= 1) {
+        return;
+    }
+
+    size_t idx = 0;
+    size_t left_child = idx * 2 + 1;
+    size_t right_child = idx * 2 + 2;
+
+    while (left_child < heap.size()) {
+        if (right_child < heap.size()) {
+            // Swap with the smaller child to maintain the min-heap property
+            if (heap[left_child] <= heap[right_child]) {
+                std::swap(heap[idx], heap[left_child]);
+                idx = left_child;
+            }
+            else {
+                std::swap(heap[idx], heap[right_child]);
+                idx = right_child;
+            }
+        }
+        else {
+            if (heap[idx] > heap[left_child]) {
+                std::swap(heap[idx], heap[left_child]);
+            }
+            idx = left_child;
+        }
+        left_child = idx * 2 + 1;
+        right_child = idx * 2 + 2;
+    }
+}
+
+template <typename T>
+T PriorityQueue<T>::peek() const{
+    if (heap.empty()) {
+        throw std::runtime_error("Heap is empty");
+    }
+    return heap[0];
+}
+template <typename T>
+size_t PriorityQueue<T>::size() const {
+    return heap.size();
+}
+
+template <typename T>
+bool PriorityQueue<T>::isEmpty() const {
+    return heap.empty();
+}
+
+template<typename T>
+void PriorityQueue<T>::clear() {
+    // Check if this actually works with std::vector.clear()
+    heap.clear();
+}
+
+

--- a/Queue/PriorityQueue.h
+++ b/Queue/PriorityQueue.h
@@ -32,7 +32,7 @@ PriorityQueue<T>::~PriorityQueue() {
 template <typename T>
 void PriorityQueue<T>::push(T value) {
     heap.push_back(value);
-    heap.heapifyUp();
+    heapifyUp();
 }
 
 template <typename T>
@@ -46,57 +46,63 @@ void PriorityQueue<T>::pop() {
     }
     std::swap(heap[0], heap.back());
     heap.pop_back();
-    heap.heapifyDown();
+    heapifyDown();
 }
 
 template<typename T>
 void PriorityQueue<T>::heapifyUp() {
-    // Empty heaps or single element heaps that never require swapping
     if (heap.size() <= 1) {
         return;
     }
 
     size_t idx = heap.size() - 1;
-    size_t parentIdx = (idx - 1) / 2;
 
-    while (idx > 0 && heap[idx] < heap[parentIdx]) {
+    while (idx > 0) {
+        size_t parentIdx = (idx - 1) / 2;
+        if (heap[idx] >= heap[parentIdx]) {
+            break;
+        }
         std::swap(heap[idx], heap[parentIdx]);
         idx = parentIdx;
-        parentIdx = (parentIdx - 1) / 2;
     }
 }
 
 template<typename T>
 void PriorityQueue<T>::heapifyDown() {
-    // Empty heaps or single element heaps that never require swapping
     if (heap.size() <= 1) {
         return;
     }
 
     size_t idx = 0;
-    size_t left_child = idx * 2 + 1;
-    size_t right_child = idx * 2 + 2;
 
-    while (left_child < heap.size()) {
-        if (right_child < heap.size()) {
-            // Swap with the smaller child to maintain the min-heap property
-            if (heap[left_child] <= heap[right_child]) {
-                std::swap(heap[idx], heap[left_child]);
-                idx = left_child;
-            }
-            else {
-                std::swap(heap[idx], heap[right_child]);
-                idx = right_child;
-            }
+    while (true) {
+        size_t left_child = idx * 2 + 1;
+        size_t right_child = idx * 2 + 2;
+
+        // If no children exist, we're done
+        if (left_child >= heap.size()) {
+            break;
         }
-        else {
-            if (heap[idx] > heap[left_child]) {
-                std::swap(heap[idx], heap[left_child]);
-            }
-            idx = left_child;
+
+        size_t smallest = idx;
+
+        // Compare with left child
+        if (heap[left_child] < heap[smallest]) {
+            smallest = left_child;
         }
-        left_child = idx * 2 + 1;
-        right_child = idx * 2 + 2;
+
+        // Compare with right child (only if it exists)
+        if (right_child < heap.size() && heap[right_child] < heap[smallest]) {
+            smallest = right_child;
+        }
+
+        // If no swap is needed, we're done
+        if (smallest == idx) {
+            break;
+        }
+
+        std::swap(heap[idx], heap[smallest]);
+        idx = smallest; // Move down the tree
     }
 }
 

--- a/tests/test_priority_queue.cpp
+++ b/tests/test_priority_queue.cpp
@@ -1,0 +1,11 @@
+#include <gtest/gtest.h>
+#include "../Queue/PriorityQueue.h"
+
+class PriorityQueueTest : public ::testing::Test {
+protected:
+    PriorityQueue<int> priorityQueue;
+
+    void SetUp() override {
+
+    }
+};

--- a/tests/test_priority_queue.cpp
+++ b/tests/test_priority_queue.cpp
@@ -7,18 +7,25 @@ protected:
     PriorityQueue<int> priorityQueue;
 
     template<typename T>
-    bool isValidMinHeap(const PriorityQueue<T> heap) {
-        for (size_t i = 0; i < heap.size(); ++i) {
-            size_t left_child = 2 * i + 1;
-            size_t right_child = 2 * i + 2;
+    bool isValidMinHeap(PriorityQueue<T> pq) {
+        // Empty heap is always valid
+        if (pq.isEmpty()) {
+            return true;
+        }
 
-            if (left_child < heap.size() && heap[i] > heap[left_child]) {
-                return false; // Min-heap violated
-            }
+        T lastValue = pq.peek();
+        pq.pop();
 
-            if (right_child < heap.size() && heap[i] > heap[right_child]) {
-                return false; // Min-heap violated
+        // Confirm all elements are in non-decreasing order
+        while (!pq.isEmpty()) {
+            T currentValue = pq.peek();
+
+            // If elements are in decreasing order, heap property is violated
+            if (currentValue < lastValue) {
+                return false;
             }
+            lastValue = currentValue;
+            pq.pop();
         }
         return true;
     }
@@ -68,49 +75,132 @@ TEST_F(PriorityQueueTest, HeapPropertyAfterMultiplePushes) {
 }
 
 TEST_F(PriorityQueueTest, HeapPropertyAfterMultiplePops) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
 
+    std::uniform_int_distribution<int> dist(1, 10000);
+    for (size_t i = 0; i < 100; ++i) {
+        priorityQueue.push(dist(gen));
+    }
+    for (size_t i = 0; i < 30; ++i) {
+        priorityQueue.pop();
+    }
+
+    EXPECT_TRUE(isValidMinHeap(priorityQueue));
 }
 
 TEST_F(PriorityQueueTest, HeapPropertyMaintainedWithDuplicates) {
 
+    for (size_t i = 0; i < 10; ++i) {
+        priorityQueue.push(10);
+    }
+
+    EXPECT_TRUE(isValidMinHeap(priorityQueue));
 }
 
 TEST_F(PriorityQueueTest, PushNegativeValues) {
-
+    for (int i = 0; i < 10; ++i) {
+        priorityQueue.push((i + 1) * -1);
+    }
+    EXPECT_TRUE(isValidMinHeap(priorityQueue));
 }
 
 TEST_F(PriorityQueueTest, PushZeroValue) {
-
+    for (int i = 0; i < 10; ++i) {
+        priorityQueue.push((0));
+    }
+    EXPECT_TRUE(isValidMinHeap(priorityQueue));
 }
 
 TEST_F(PriorityQueueTest, PopUntilEmpty) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
 
+    std::uniform_int_distribution<int> dist(1, 10000);
+    for (size_t i = 0; i < 100; ++i) {
+        priorityQueue.push(dist(gen));
+    }
+    for (size_t i = 0; i < 100; ++i) {
+        priorityQueue.pop();
+    }
+    ASSERT_TRUE(priorityQueue.isEmpty());
+    ASSERT_EQ(priorityQueue.size(), 0);
 }
 
 TEST_F(PriorityQueueTest, PushAndPopInterweaved) {
+    for (int i = 0; i < 20; ++i) {
+        priorityQueue.push(i);
+        if (i % 3 == 0) {
+            priorityQueue.pop();
+        }
+    }
+    ASSERT_FALSE(priorityQueue.isEmpty());
+    ASSERT_TRUE(isValidMinHeap(priorityQueue));
 
+    while (!priorityQueue.isEmpty()) {
+        priorityQueue.pop();
+    }
+
+    // Ensure it's empty after clearing
+    ASSERT_TRUE(priorityQueue.isEmpty());
 }
 
 TEST_F(PriorityQueueTest, PushLargeNumberOfElements) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
 
+    std::uniform_int_distribution<int> dist(1, 10000);
+
+    for (int i = 0; i < 100000; ++i) {
+        priorityQueue.push(dist(gen)); // Insert random values
+    }
 }
 
 TEST_F(PriorityQueueTest, PopLargeNumberofElements) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
 
+    std::uniform_int_distribution<int> dist(1, 10000);
+
+    for (int i = 0; i < 100000; ++i) {
+        priorityQueue.push(dist(gen)); // Insert random values
+    }
+
+    while(!priorityQueue.isEmpty()) {
+        priorityQueue.pop();
+    }
+
+    EXPECT_TRUE(priorityQueue.isEmpty());
 }
 
 TEST_F(PriorityQueueTest, PushAndPopLargeInterweaving) {
-
+    for (int i = 0; i < 100000; ++i) {
+        priorityQueue.push(i);
+        if (i % 2 == 0) {
+            priorityQueue.pop();
+        }
+    }
+    EXPECT_TRUE(isValidMinHeap(priorityQueue));
 }
 
 TEST_F(PriorityQueueTest, ClearHeap) {
-
+    for (int i = 0; i < 10; ++i) {
+        priorityQueue.push((i + 1) * -1);
+    }
+    priorityQueue.clear();
+    EXPECT_TRUE(priorityQueue.isEmpty());
 }
 
 TEST_F(PriorityQueueTest, IsEmptyReturnsTrueOnEmptyHeap) {
-
+    EXPECT_TRUE(priorityQueue.isEmpty());
 }
 
 TEST_F(PriorityQueueTest, SizeAfterPushesAndPops) {
+    priorityQueue.push(1);
+    priorityQueue.pop();
+    priorityQueue.push(2);
+    priorityQueue.push(3);
+    priorityQueue.pop();
 
+    EXPECT_EQ(priorityQueue.size(), 1);
 }

--- a/tests/test_priority_queue.cpp
+++ b/tests/test_priority_queue.cpp
@@ -1,11 +1,116 @@
 #include <gtest/gtest.h>
 #include "../Queue/PriorityQueue.h"
+#include <random>
 
 class PriorityQueueTest : public ::testing::Test {
 protected:
     PriorityQueue<int> priorityQueue;
 
+    template<typename T>
+    bool isValidMinHeap(const PriorityQueue<T> heap) {
+        for (size_t i = 0; i < heap.size(); ++i) {
+            size_t left_child = 2 * i + 1;
+            size_t right_child = 2 * i + 2;
+
+            if (left_child < heap.size() && heap[i] > heap[left_child]) {
+                return false; // Min-heap violated
+            }
+
+            if (right_child < heap.size() && heap[i] > heap[right_child]) {
+                return false; // Min-heap violated
+            }
+        }
+        return true;
+    }
+
     void SetUp() override {
 
     }
 };
+
+TEST_F(PriorityQueueTest, EmptyHeapPeekThrowsException) {
+    EXPECT_THROW(priorityQueue.peek(), std::runtime_error);
+}
+
+TEST_F(PriorityQueueTest, EmptyHeapPopThrowsException) {
+    EXPECT_THROW(priorityQueue.pop(), std::runtime_error);
+}
+
+TEST_F(PriorityQueueTest, PushSingleElement) {
+    priorityQueue.push(5);
+    EXPECT_EQ(priorityQueue.peek(), 5);
+}
+
+TEST_F(PriorityQueueTest, PopSingleElement) {
+    priorityQueue.push(5);
+    priorityQueue.push(10);
+
+    priorityQueue.pop();
+
+    EXPECT_EQ(priorityQueue.peek(), 10);
+}
+
+TEST_F(PriorityQueueTest, PeekSingleElement) {
+    priorityQueue.push(26);
+
+    EXPECT_EQ(priorityQueue.peek(), 26);
+}
+
+TEST_F(PriorityQueueTest, HeapPropertyAfterMultiplePushes) {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+
+    std::uniform_int_distribution<int> dist(1, 10000);
+    for (size_t i = 0; i < 10; ++i) {
+        priorityQueue.push(dist(gen));
+    }
+    EXPECT_TRUE(isValidMinHeap(priorityQueue));
+}
+
+TEST_F(PriorityQueueTest, HeapPropertyAfterMultiplePops) {
+
+}
+
+TEST_F(PriorityQueueTest, HeapPropertyMaintainedWithDuplicates) {
+
+}
+
+TEST_F(PriorityQueueTest, PushNegativeValues) {
+
+}
+
+TEST_F(PriorityQueueTest, PushZeroValue) {
+
+}
+
+TEST_F(PriorityQueueTest, PopUntilEmpty) {
+
+}
+
+TEST_F(PriorityQueueTest, PushAndPopInterweaved) {
+
+}
+
+TEST_F(PriorityQueueTest, PushLargeNumberOfElements) {
+
+}
+
+TEST_F(PriorityQueueTest, PopLargeNumberofElements) {
+
+}
+
+TEST_F(PriorityQueueTest, PushAndPopLargeInterweaving) {
+
+}
+
+TEST_F(PriorityQueueTest, ClearHeap) {
+
+}
+
+TEST_F(PriorityQueueTest, IsEmptyReturnsTrueOnEmptyHeap) {
+
+}
+
+TEST_F(PriorityQueueTest, SizeAfterPushesAndPops) {
+
+}


### PR DESCRIPTION
# Add PriorityQueue 

## Description
This pull request introduces the implementation of a `PriorityQueue` class using a binary heap for efficient priority-based operations. It includes:
- Implementation of core methods (`push`, `pop`, `peek`, etc.) with adherence to min-heap properties.
- Unit tests to validate functionality, covering edge cases and stress scenarios.

## Type of Changes
- [x] New feature (non-breaking)
- [ ] Bug fix (non-breaking)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist of Changes
The following files have been added or updated as part of this pull request:
- [x] **`PriorityQueue.h`** – Contains the implementation of the `PriorityQueue` class with `heapifyUp` and `heapifyDown` methods.
- [x] **`PriorityQueueTest.cpp`** – Unit tests using Google Test to validate `PriorityQueue` functionality.

## How to Test
1. **Build the Project:**
   - Use CMake to configure and build the project:
     ```bash
     cmake -S . -B build
     cmake --build build
     ```
2. **Run Unit Tests:**
   - Execute the test suite:
     ```bash
     ./build/tests/PriorityQueueTest
     ```
   - Ensure all tests pass, including:
     - Basic functionality (`push`, `pop`, `peek`, etc.).
     - Edge cases (empty heap, single-element heap, duplicates).
     - Stress tests (large interleaved operations).

3. **Validation of Results:**
   - Verify that all tests return `PASSED`.

## Notes / Additional Context
- This implementation adheres to a min-heap design. Users can simulate a max-heap by negating their values.
- The `isValidMinHeap` helper function was used extensively in testing to validate the heap property.
- Future improvements could include parameterizing the `PriorityQueue` to support custom comparison functions for max-heap or other variations.
